### PR TITLE
[codex] hide platform loader headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Removed platform dynamic-loader headers from `plugin_loader.hpp`; Windows consumers no longer inherit `windows.h` macros from this public header.
+- Moved plugin loader native handles and factory-function state behind a private PImpl with RAII library unloading.
+- Added a public-header hygiene compile test for Win32 `min`/`max` macro leakage.
+
 ## Issue #18 - Watcher-based plugin hot-reload
 
 - Added automatic plugin file watching in `PluginLoader`, with `efsw` integration when available.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A lightweight, cross-platform plugin system in modern C++ with support for runti
 - 🔥 **Watcher-Based Hot-Reloading**: Queue reloads from a background watcher and apply them on your host loop
 - 🌐 **Cross-Platform**: Works on Windows (.dll), Linux (.so), and macOS (.dylib)
 - 🎯 **Clean Interface**: Simple, intuitive plugin API
+- **Header Hygiene**: Public headers avoid platform dynamic-loader headers such as `windows.h`
 - 🛠️ **Modern C++**: Uses C++17 features for clean, maintainable code
 - 🚀 **Pragmatic Fallbacks**: Uses `efsw` when available and falls back to built-in polling when it is not
 

--- a/include/hotplugpp/plugin_loader.hpp
+++ b/include/hotplugpp/plugin_loader.hpp
@@ -2,37 +2,11 @@
 
 #include "i_plugin.hpp"
 
-#include <chrono>
 #include <functional>
 #include <memory>
 #include <string>
 
-// Platform-specific includes
-#ifdef _WIN32
-#include <windows.h>
-typedef HMODULE LibraryHandle;
-#else
-#include <dlfcn.h>
-typedef void* LibraryHandle;
-#endif
-
 namespace hotplugpp {
-namespace detail {
-class PluginWatcher;
-}
-
-/**
- * @brief Plugin metadata and handle
- */
-struct PluginInfo {
-    std::string path;
-    LibraryHandle handle = nullptr;
-    IPlugin* instance = nullptr;
-    CreatePluginFunc createFunc = nullptr;
-    DestroyPluginFunc destroyFunc = nullptr;
-    std::chrono::system_clock::time_point lastModified;
-    bool isLoaded = false;
-};
 
 /**
  * @brief Manages dynamic loading, unloading, and hot-reloading of plugins
@@ -110,43 +84,8 @@ class PluginLoader {
     void setReloadCallback(std::function<void()> callback);
 
   private:
-    PluginInfo m_pluginInfo;
-    std::function<void()> m_reloadCallback;
-    std::unique_ptr<detail::PluginWatcher> m_watcher;
-
-    /**
-     * @brief Get the last modification time of a file
-     * @param path File path
-     * @return Last modification time
-     */
-    std::chrono::system_clock::time_point getFileModificationTime(const std::string& path);
-
-    /**
-     * @brief Load a shared library
-     * @param path Library path
-     * @return Library handle or nullptr on failure
-     */
-    LibraryHandle loadLibrary(const std::string& path);
-
-    /**
-     * @brief Unload a shared library
-     * @param handle Library handle
-     */
-    void unloadLibrary(LibraryHandle handle);
-
-    /**
-     * @brief Get a function pointer from a library
-     * @param handle Library handle
-     * @param name Function name
-     * @return Function pointer or nullptr on failure
-     */
-    void* getFunction(LibraryHandle handle, const std::string& name);
-
-    /**
-     * @brief Get the last error message from dynamic library loading
-     * @return Error message string
-     */
-    std::string getLastError();
+    struct Impl;
+    std::unique_ptr<Impl> m_impl;
 };
 
 } // namespace hotplugpp

--- a/src/plugin_loader.cpp
+++ b/src/plugin_loader.cpp
@@ -2,11 +2,19 @@
 
 #include "plugin_watcher.hpp"
 
+#include <chrono>
+#include <filesystem>
 #include <iostream>
 #include <optional>
 #include <utility>
 
 #ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #else
 #include <dlfcn.h>
@@ -18,192 +26,86 @@ namespace hotplugpp {
 
 namespace {
 
-// Returns nullopt when the file is inaccessible (does not exist, permission denied, etc.).
-std::optional<std::chrono::system_clock::time_point>
-getFileModificationTimeForWatch(const std::string& path) {
-    struct stat statbuf;
-    if (stat(path.c_str(), &statbuf) == 0) {
-        return std::chrono::system_clock::from_time_t(statbuf.st_mtime);
-    }
-    return std::nullopt;
-}
+class DynamicLibrary {
+  public:
+    DynamicLibrary() = default;
+    ~DynamicLibrary() { reset(); }
 
-} // namespace
+    DynamicLibrary(const DynamicLibrary&) = delete;
+    DynamicLibrary& operator=(const DynamicLibrary&) = delete;
 
-PluginLoader::PluginLoader() : m_watcher(std::make_unique<detail::PluginWatcher>()) {}
+    DynamicLibrary(DynamicLibrary&& other) noexcept
+        : m_handle(std::exchange(other.m_handle, nullptr)) {}
 
-PluginLoader::~PluginLoader() {
-    unloadPlugin();
-}
-
-bool PluginLoader::loadPlugin(const std::string& path) {
-    if (isLoaded()) {
-        unloadPlugin();
-    }
-
-    LibraryHandle handle = loadLibrary(path);
-    if (!handle) {
-        std::cerr << "Failed to load library: " << path << std::endl;
-        std::cerr << "Error: " << getLastError() << std::endl;
-        return false;
-    }
-
-    CreatePluginFunc createFunc = reinterpret_cast<CreatePluginFunc>(
-        getFunction(handle, "createPlugin"));
-    DestroyPluginFunc destroyFunc = reinterpret_cast<DestroyPluginFunc>(
-        getFunction(handle, "destroyPlugin"));
-
-    if (!createFunc || !destroyFunc) {
-        std::cerr << "Failed to find plugin factory functions in: " << path << std::endl;
-        std::cerr << "Error: " << getLastError() << std::endl;
-        unloadLibrary(handle);
-        return false;
-    }
-
-    IPlugin* plugin = createFunc();
-    if (!plugin) {
-        std::cerr << "Failed to create plugin instance from: " << path << std::endl;
-        unloadLibrary(handle);
-        return false;
-    }
-
-    if (!plugin->onLoad()) {
-        std::cerr << "Plugin initialization failed: " << path << std::endl;
-        destroyFunc(plugin);
-        unloadLibrary(handle);
-        return false;
-    }
-
-    m_pluginInfo.path = path;
-    m_pluginInfo.handle = handle;
-    m_pluginInfo.instance = plugin;
-    m_pluginInfo.createFunc = createFunc;
-    m_pluginInfo.destroyFunc = destroyFunc;
-    m_pluginInfo.lastModified = getFileModificationTime(path);
-    m_pluginInfo.isLoaded = true;
-
-    if (!m_watcher->start(path)) {
-        std::cerr << "Continuing without file watcher for: " << path << std::endl;
-    }
-
-    std::cout << "Plugin loaded successfully: " << plugin->getName() << " v"
-              << plugin->getVersion().toString() << std::endl;
-
-    return true;
-}
-
-void PluginLoader::unloadPlugin() {
-    if (!isLoaded()) {
-        return;
-    }
-
-    m_watcher->stop();
-
-    if (m_pluginInfo.instance) {
-        m_pluginInfo.instance->onUnload();
-        if (m_pluginInfo.destroyFunc) {
-            m_pluginInfo.destroyFunc(m_pluginInfo.instance);
+    DynamicLibrary& operator=(DynamicLibrary&& other) noexcept {
+        if (this != &other) {
+            reset();
+            m_handle = std::exchange(other.m_handle, nullptr);
         }
-        m_pluginInfo.instance = nullptr;
+        return *this;
     }
 
-    if (m_pluginInfo.handle) {
-        unloadLibrary(m_pluginInfo.handle);
-        m_pluginInfo.handle = nullptr;
+    [[nodiscard]] bool load(const std::string& path) {
+        reset();
+
+#ifdef _WIN32
+        const std::filesystem::path nativePath(path);
+        m_handle = LoadLibraryW(nativePath.c_str());
+#else
+        dlerror();
+        m_handle = dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL);
+#endif
+
+        return m_handle != nullptr;
     }
 
-    m_pluginInfo.isLoaded = false;
-    m_pluginInfo.createFunc = nullptr;
-    m_pluginInfo.destroyFunc = nullptr;
-}
-
-PluginLoader::ReloadResult PluginLoader::checkAndReload() {
-    if (!isLoaded()) {
-        return ReloadResult::NoChange;
-    }
-
-    const auto currentModTime = getFileModificationTime(m_pluginInfo.path);
-    if (m_watcher->consumeReloadSignal(currentModTime, m_pluginInfo.lastModified)) {
-        std::cout << "Plugin file modified, reloading..." << std::endl;
-
-        const std::string path = m_pluginInfo.path;
-        unloadPlugin();
-
-        if (loadPlugin(path)) {
-            if (m_reloadCallback) {
-                m_reloadCallback();
-            }
-            return ReloadResult::Reloaded;
+    void reset() noexcept {
+        if (!m_handle) {
+            return;
         }
 
-        std::cerr << "Failed to reload plugin: " << path << std::endl;
-        return ReloadResult::ReloadFailed;
+#ifdef _WIN32
+        FreeLibrary(m_handle);
+#else
+        dlclose(m_handle);
+#endif
+        m_handle = nullptr;
     }
 
-    return ReloadResult::NoChange;
-}
+    [[nodiscard]] explicit operator bool() const noexcept { return m_handle != nullptr; }
 
-IPlugin* PluginLoader::getPlugin() const {
-    return m_pluginInfo.instance;
-}
+    [[nodiscard]] void* symbol(const std::string& name) const {
+        if (!m_handle) {
+            return nullptr;
+        }
 
-bool PluginLoader::isLoaded() const {
-    return m_pluginInfo.isLoaded && m_pluginInfo.instance != nullptr;
-}
-
-std::string PluginLoader::getPluginPath() const {
-    return m_pluginInfo.path;
-}
-
-void PluginLoader::setReloadCallback(std::function<void()> callback) {
-    m_reloadCallback = std::move(callback);
-}
-
-std::chrono::system_clock::time_point
-PluginLoader::getFileModificationTime(const std::string& path) {
-    return getFileModificationTimeForWatch(path).value_or(std::chrono::system_clock::time_point{});
-}
-
-LibraryHandle PluginLoader::loadLibrary(const std::string& path) {
 #ifdef _WIN32
-    return LoadLibraryA(path.c_str());
+        return reinterpret_cast<void*>(GetProcAddress(m_handle, name.c_str()));
 #else
-    return dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL);
+        return dlsym(m_handle, name.c_str());
 #endif
-}
+    }
 
-void PluginLoader::unloadLibrary(LibraryHandle handle) {
-    if (!handle)
-        return;
-
+  private:
 #ifdef _WIN32
-    FreeLibrary(handle);
+    HMODULE m_handle = nullptr;
 #else
-    dlclose(handle);
+    void* m_handle = nullptr;
 #endif
-}
+};
 
-void* PluginLoader::getFunction(LibraryHandle handle, const std::string& name) {
-    if (!handle)
-        return nullptr;
-
+std::string getLastDynamicLibraryError() {
 #ifdef _WIN32
-    return reinterpret_cast<void*>(GetProcAddress(handle, name.c_str()));
-#else
-    return dlsym(handle, name.c_str());
-#endif
-}
-
-std::string PluginLoader::getLastError() {
-#ifdef _WIN32
-    DWORD error = GetLastError();
-    if (error == 0)
+    const DWORD error = GetLastError();
+    if (error == 0) {
         return "No error";
+    }
 
     LPSTR messageBuffer = nullptr;
-    size_t size = FormatMessageA(
-        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-        NULL, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
+    const size_t size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+                                           FORMAT_MESSAGE_IGNORE_INSERTS,
+                                       nullptr, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                                       reinterpret_cast<LPSTR>(&messageBuffer), 0, nullptr);
 
     if (size == 0 || messageBuffer == nullptr) {
         return "Unknown error (code: " + std::to_string(error) + ")";
@@ -216,6 +118,204 @@ std::string PluginLoader::getLastError() {
     const char* error = dlerror();
     return error ? std::string(error) : "No error";
 #endif
+}
+
+// Returns nullopt when the file is inaccessible (does not exist, permission denied, etc.).
+std::optional<std::chrono::system_clock::time_point>
+getFileModificationTimeForWatch(const std::string& path) {
+    struct stat statbuf;
+    if (stat(path.c_str(), &statbuf) == 0) {
+        return std::chrono::system_clock::from_time_t(statbuf.st_mtime);
+    }
+    return std::nullopt;
+}
+
+struct LoadedPlugin {
+    std::string path;
+    DynamicLibrary library;
+    IPlugin* instance = nullptr;
+    CreatePluginFunc createFunc = nullptr;
+    DestroyPluginFunc destroyFunc = nullptr;
+    std::chrono::system_clock::time_point lastModified;
+    bool isLoaded = false;
+};
+
+} // namespace
+
+struct PluginLoader::Impl {
+    Impl() : watcher(std::make_unique<detail::PluginWatcher>()) {}
+
+    ~Impl() { unloadPlugin(); }
+
+    bool loadPlugin(const std::string& path) {
+        if (isLoaded()) {
+            unloadPlugin();
+        }
+
+        DynamicLibrary library;
+        if (!library.load(path)) {
+            std::cerr << "Failed to load library: " << path << std::endl;
+            std::cerr << "Error: " << getLastDynamicLibraryError() << std::endl;
+            return false;
+        }
+
+        void* createSymbol = library.symbol("createPlugin");
+        if (!createSymbol) {
+            std::cerr << "Failed to find createPlugin in: " << path << std::endl;
+            std::cerr << "Error: " << getLastDynamicLibraryError() << std::endl;
+            return false;
+        }
+
+        void* destroySymbol = library.symbol("destroyPlugin");
+        if (!destroySymbol) {
+            std::cerr << "Failed to find destroyPlugin in: " << path << std::endl;
+            std::cerr << "Error: " << getLastDynamicLibraryError() << std::endl;
+            return false;
+        }
+
+        CreatePluginFunc createFunc = reinterpret_cast<CreatePluginFunc>(createSymbol);
+        DestroyPluginFunc destroyFunc = reinterpret_cast<DestroyPluginFunc>(destroySymbol);
+
+        IPlugin* plugin = createFunc();
+        if (!plugin) {
+            std::cerr << "Failed to create plugin instance from: " << path << std::endl;
+            return false;
+        }
+
+        if (!plugin->onLoad()) {
+            std::cerr << "Plugin initialization failed: " << path << std::endl;
+            destroyFunc(plugin);
+            return false;
+        }
+
+        pluginInfo.path = path;
+        pluginInfo.library = std::move(library);
+        pluginInfo.instance = plugin;
+        pluginInfo.createFunc = createFunc;
+        pluginInfo.destroyFunc = destroyFunc;
+        pluginInfo.lastModified = getFileModificationTime(path);
+        pluginInfo.isLoaded = true;
+
+        if (!watcher->start(path)) {
+            std::cerr << "Continuing without file watcher for: " << path << std::endl;
+        }
+
+        std::cout << "Plugin loaded successfully: " << plugin->getName() << " v"
+                  << plugin->getVersion().toString() << std::endl;
+
+        return true;
+    }
+
+    void unloadPlugin() {
+        if (!isLoaded()) {
+            return;
+        }
+
+        watcher->stop();
+
+        if (pluginInfo.instance) {
+            pluginInfo.instance->onUnload();
+            if (pluginInfo.destroyFunc) {
+                pluginInfo.destroyFunc(pluginInfo.instance);
+            }
+            pluginInfo.instance = nullptr;
+        }
+
+        pluginInfo.library.reset();
+        pluginInfo.isLoaded = false;
+        pluginInfo.createFunc = nullptr;
+        pluginInfo.destroyFunc = nullptr;
+    }
+
+    PluginLoader::ReloadResult checkAndReload() {
+        if (!isLoaded()) {
+            return PluginLoader::ReloadResult::NoChange;
+        }
+
+        const auto currentModTime = getFileModificationTime(pluginInfo.path);
+        if (watcher->consumeReloadSignal(currentModTime, pluginInfo.lastModified)) {
+            std::cout << "Plugin file modified, reloading..." << std::endl;
+
+            const std::string path = pluginInfo.path;
+            unloadPlugin();
+
+            if (loadPlugin(path)) {
+                if (reloadCallback) {
+                    reloadCallback();
+                }
+                return PluginLoader::ReloadResult::Reloaded;
+            }
+
+            std::cerr << "Failed to reload plugin: " << path << std::endl;
+            return PluginLoader::ReloadResult::ReloadFailed;
+        }
+
+        return PluginLoader::ReloadResult::NoChange;
+    }
+
+    [[nodiscard]] IPlugin* getPlugin() const noexcept { return pluginInfo.instance; }
+
+    [[nodiscard]] bool isLoaded() const noexcept {
+        return pluginInfo.isLoaded && pluginInfo.instance != nullptr &&
+               static_cast<bool>(pluginInfo.library);
+    }
+
+    [[nodiscard]] std::string getPluginPath() const { return pluginInfo.path; }
+
+    void setReloadCallback(std::function<void()> callback) { reloadCallback = std::move(callback); }
+
+    [[nodiscard]] std::chrono::system_clock::time_point
+    getFileModificationTime(const std::string& path) const {
+        return getFileModificationTimeForWatch(path).value_or(
+            std::chrono::system_clock::time_point{});
+    }
+
+    LoadedPlugin pluginInfo;
+    std::function<void()> reloadCallback;
+    std::unique_ptr<detail::PluginWatcher> watcher;
+};
+
+PluginLoader::PluginLoader() : m_impl(std::make_unique<Impl>()) {}
+
+PluginLoader::~PluginLoader() = default;
+
+bool PluginLoader::loadPlugin(const std::string& path) {
+    if (!m_impl) {
+        m_impl = std::make_unique<Impl>();
+    }
+    return m_impl->loadPlugin(path);
+}
+
+void PluginLoader::unloadPlugin() {
+    if (m_impl) {
+        m_impl->unloadPlugin();
+    }
+}
+
+PluginLoader::ReloadResult PluginLoader::checkAndReload() {
+    if (!m_impl) {
+        return ReloadResult::NoChange;
+    }
+    return m_impl->checkAndReload();
+}
+
+IPlugin* PluginLoader::getPlugin() const {
+    return m_impl ? m_impl->getPlugin() : nullptr;
+}
+
+bool PluginLoader::isLoaded() const {
+    return m_impl != nullptr && m_impl->isLoaded();
+}
+
+std::string PluginLoader::getPluginPath() const {
+    return m_impl ? m_impl->getPluginPath() : std::string{};
+}
+
+void PluginLoader::setReloadCallback(std::function<void()> callback) {
+    if (!m_impl) {
+        m_impl = std::make_unique<Impl>();
+    }
+    m_impl->setReloadCallback(std::move(callback));
 }
 
 } // namespace hotplugpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -105,6 +105,7 @@ set_target_properties(failing_plugin PROPERTIES
 # parallel Visual Studio builds.
 add_executable(hotplugpp_tests
     version_tests.cpp
+    plugin_loader_header_tests.cpp
     plugin_loader_tests.cpp
     i_plugin_tests.cpp
     integration_tests.cpp

--- a/tests/plugin_loader_header_tests.cpp
+++ b/tests/plugin_loader_header_tests.cpp
@@ -1,0 +1,25 @@
+#include "hotplugpp/plugin_loader.hpp"
+
+#ifdef _WIN32
+#ifdef min
+#error "plugin_loader.hpp must not expose the Windows min macro"
+#endif
+
+#ifdef max
+#error "plugin_loader.hpp must not expose the Windows max macro"
+#endif
+#endif
+
+#include <gtest/gtest.h>
+
+namespace hotplugpp {
+namespace tests {
+
+TEST(PluginLoaderHeaderTest, PublicHeaderDoesNotRequirePlatformHeaders) {
+    PluginLoader loader;
+
+    EXPECT_FALSE(loader.isLoaded());
+}
+
+} // namespace tests
+} // namespace hotplugpp


### PR DESCRIPTION
## Summary

- Remove platform dynamic-loader headers from the public `plugin_loader.hpp` contract.
- Move native library ownership and plugin loader internals behind a private PImpl with RAII cleanup.
- Add a compile-time header hygiene test for Win32 `min`/`max` macro leakage.
- Document the header hygiene change in README and CHANGELOG.

## Root Cause

`plugin_loader.hpp` exposed `windows.h` on Windows through the public `LibraryHandle` typedef. Any consumer including the loader header inherited Win32 macros such as `min` and `max`.

## Validation

- `cmake -S . -B build`
- `cmake --build build --config Release --parallel`
- `ctest --test-dir build -C Release --output-on-failure`
- `cmake -P scripts/check-format.cmake`
- `clang-tidy src/plugin_loader.cpp -p build --quiet`

Draft PR for review.
