### PR TITLE
fix: Windows hot-reload DLL lock via co-located shadow copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
 - Removed platform dynamic-loader headers from `plugin_loader.hpp`; Windows consumers no longer inherit `windows.h` macros from this public header.
 - Moved plugin loader native handles and factory-function state behind a private PImpl with RAII library unloading.
 - Added a public-header hygiene compile test for Win32 `min`/`max` macro leakage.
+- Fixed hot-reload on Windows: `PluginLoader` now loads a co-located **shadow copy**
+  of the plugin library instead of the build-output file directly, so the OS lock on
+  a loaded `.dll` no longer prevents a rebuild from overwriting the original. Applied
+  on all platforms.
+- The shadow copy is created next to the original
+  (`.hotplugpp-shadow-<name>-<pid>-<n>.<ext>`) and removed on unload, reload, and
+  failed load; co-locating it preserves dependency resolution on Windows and
+  `$ORIGIN`/`@loader_path` on POSIX. Falls back to a direct load when the plugin
+  directory is not writable.
+- Added regression tests: overwriting a loaded library now reloads, shadow copies
+  are removed after unload, and a failed load leaves none behind.
 
 ## Issue #18 - Watcher-based plugin hot-reload
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ To force the polling watcher even when `efsw` is available:
 cmake -S . -B build -DHOTPLUGPP_USE_EFSW=OFF
 ```
 
+### File locking and shadow copies
+
+To keep hot-reload working on Windows, `PluginLoader` never loads your build-output
+file directly. On load it copies the library to a uniquely named **shadow copy** in
+the same directory (e.g. `.hotplugpp-shadow-<name>-<pid>-<n>.dll`) and loads that
+copy. The original file is left unlocked, so your build can overwrite it and the
+watcher can trigger a reload; the shadow copy is removed on unload and reload. If
+the plugin directory is not writable, HotPlugPP falls back to loading the original
+directly (hot-reload may not work on Windows in that case). Shadow copies match the
+ignored `*.dll`/`*.so`/`*.dylib` patterns, so they are never committed.
+
 ## CMake Options
 
 | Option | Default | Description |

--- a/docs/hot-reload-watcher.md
+++ b/docs/hot-reload-watcher.md
@@ -32,6 +32,27 @@ cmake -S . -B build -DHOTPLUGPP_FETCH_EFSW=OFF
 - `checkAndReload()` must still be called from the host loop to apply the reload safely.
 - Rapid duplicate file notifications are debounced so one rebuild triggers one reload.
 
+## Why rebuilds work while the plugin is loaded (shadow copy)
+
+On Windows the OS holds an exclusive lock on a loaded `.dll`, so loading the
+build-output file directly would block the next rebuild from overwriting it and
+hot-reload would never fire. To avoid this, `PluginLoader` loads a **shadow copy**:
+
+- On load it copies the library to a uniquely named sibling file in the same
+  directory (`.hotplugpp-shadow-<name>-<pid>-<n>.<ext>`) and loads that copy
+  (`LoadLibraryW` on Windows, `dlopen` on POSIX). The original build-output file is
+  never opened by the loader, so it stays writable for rebuilds.
+- The shadow copy lives in the *same* directory as the original (not a temp dir),
+  so dependency resolution is unchanged on Windows and `$ORIGIN`/`@loader_path`
+  dependencies keep resolving on POSIX.
+- The shadow filename differs from the watched original, so the watcher ignores
+  shadow create/delete events — there is no reload loop.
+- Shadow copies are deleted on unload, on reload, and on a failed load. A rare
+  crash may leave one behind; they are gitignored and harmless.
+- If the plugin directory is not writable, the loader falls back to loading the
+  original file directly. Loading still succeeds, but on Windows the original is
+  then locked, so hot-reload may not work until the plugin is unloaded.
+
 ## Local verification
 
 ```bash

--- a/src/plugin_loader.cpp
+++ b/src/plugin_loader.cpp
@@ -2,10 +2,13 @@
 
 #include "plugin_watcher.hpp"
 
+#include <atomic>
 #include <chrono>
 #include <filesystem>
 #include <iostream>
 #include <optional>
+#include <system_error>
+#include <thread>
 #include <utility>
 
 #ifdef _WIN32
@@ -18,6 +21,7 @@
 #include <windows.h>
 #else
 #include <dlfcn.h>
+#include <unistd.h>
 #endif
 
 #include <sys/stat.h>
@@ -25,6 +29,78 @@
 namespace hotplugpp {
 
 namespace {
+
+namespace fs = std::filesystem;
+
+// Filename prefix for the loader's co-located shadow copies. Kept in sync with the
+// test suite (tests/plugin_loader_tests.cpp).
+constexpr const char* kShadowPrefix = ".hotplugpp-shadow-";
+// A rebuild's linker may briefly hold the output file when the watcher fires;
+// retry the copy a few times before giving up.
+constexpr int kCopyRetries = 20;
+constexpr auto kCopyRetryDelay = std::chrono::milliseconds(25);
+
+unsigned long currentProcessId() {
+#ifdef _WIN32
+    return static_cast<unsigned long>(GetCurrentProcessId());
+#else
+    return static_cast<unsigned long>(getpid());
+#endif
+}
+
+// Copies originalPath to a uniquely named sibling file (same directory) and returns
+// the absolute shadow path, or nullopt if no copy could be made. Loading this copy
+// instead of the original keeps the build-output file unlocked so a rebuild can
+// overwrite it (fixes the Windows DLL lock that broke hot-reload).
+std::optional<std::string> makeShadowCopy(const std::string& originalPath) {
+    if (originalPath.empty()) {
+        return std::nullopt;
+    }
+
+    std::error_code ec;
+    fs::path original = fs::absolute(originalPath, ec);
+    if (ec) {
+        original = fs::path(originalPath);
+        ec.clear();
+    }
+
+    fs::path directory = original.has_parent_path() ? original.parent_path() : fs::current_path(ec);
+    if (ec || directory.empty()) {
+        return std::nullopt;
+    }
+    // Normalize once so the returned shadow path (later used for removal) is absolute.
+    if (fs::path absoluteDir = fs::absolute(directory, ec); !ec) {
+        directory = std::move(absoluteDir);
+    }
+
+    // Process-unique, monotonic name: the atomic counter never repeats within a run,
+    // and copy_file(overwrite_existing) tolerates a stale leftover from a previous
+    // run that happened to reuse this pid.
+    static std::atomic<unsigned long long> counter{0};
+    const std::string name = std::string(kShadowPrefix) + original.stem().string() + "-" +
+                             std::to_string(currentProcessId()) + "-" +
+                             std::to_string(counter.fetch_add(1)) + original.extension().string();
+    const fs::path shadow = directory / name;
+
+    for (int attempt = 0; attempt < kCopyRetries; ++attempt) {
+        ec.clear();
+        fs::copy_file(original, shadow, fs::copy_options::overwrite_existing, ec);
+        if (!ec) {
+            return shadow.string();
+        }
+        // A missing source will not reappear; the retry budget exists only for a
+        // rebuild's transient write lock, so do not burn it here.
+        if (ec == std::errc::no_such_file_or_directory) {
+            break;
+        }
+        std::this_thread::sleep_for(kCopyRetryDelay);
+    }
+
+    // Remove any partial candidate so a failed copy is not left behind.
+    std::error_code removeEc;
+    fs::remove(shadow, removeEc);
+    return std::nullopt;
+}
 
 class DynamicLibrary {
   public:
@@ -35,12 +111,17 @@ class DynamicLibrary {
     DynamicLibrary& operator=(const DynamicLibrary&) = delete;
 
     DynamicLibrary(DynamicLibrary&& other) noexcept
-        : m_handle(std::exchange(other.m_handle, nullptr)) {}
+        : m_handle(std::exchange(other.m_handle, nullptr)),
+          m_shadowPath(std::move(other.m_shadowPath)) {
+        other.m_shadowPath.clear();
+    }
 
     DynamicLibrary& operator=(DynamicLibrary&& other) noexcept {
         if (this != &other) {
             reset();
             m_handle = std::exchange(other.m_handle, nullptr);
+            m_shadowPath = std::move(other.m_shadowPath);
+            other.m_shadowPath.clear();
         }
         return *this;
     }
@@ -48,28 +129,47 @@ class DynamicLibrary {
     [[nodiscard]] bool load(const std::string& path) {
         reset();
 
+        // Prefer loading a co-located shadow copy so the original stays unlocked.
+        if (std::optional<std::string> shadow = makeShadowCopy(path)) {
+            if (loadNative(*shadow)) {
+                m_shadowPath = std::move(*shadow);
+                return true;
+            }
+            // The copy is the same bytes as the original, so do not retry the
+            // original. Remove the copy, preserving the load error (on Windows the
+            // removal's DeleteFileW would otherwise overwrite GetLastError).
 #ifdef _WIN32
-        const std::filesystem::path nativePath(path);
-        m_handle = LoadLibraryW(nativePath.c_str());
-#else
-        dlerror();
-        m_handle = dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL);
+            const DWORD loadError = ::GetLastError();
 #endif
+            std::error_code ec;
+            fs::remove(*shadow, ec);
+#ifdef _WIN32
+            ::SetLastError(loadError);
+#endif
+            return false;
+        }
 
-        return m_handle != nullptr;
+        // No shadow copy could be made (e.g. a read-only directory): load the
+        // original directly, preserving the historical behavior. On Windows the
+        // original is then locked, so hot-reload may not work for it.
+        return loadNative(path);
     }
 
     void reset() noexcept {
-        if (!m_handle) {
-            return;
+        if (m_handle) {
+#ifdef _WIN32
+            FreeLibrary(m_handle);
+#else
+            dlclose(m_handle);
+#endif
+            m_handle = nullptr;
         }
 
-#ifdef _WIN32
-        FreeLibrary(m_handle);
-#else
-        dlclose(m_handle);
-#endif
-        m_handle = nullptr;
+        if (!m_shadowPath.empty()) {
+            std::error_code ec;
+            fs::remove(m_shadowPath, ec); // best-effort
+            m_shadowPath.clear();
+        }
     }
 
     [[nodiscard]] explicit operator bool() const noexcept { return m_handle != nullptr; }
@@ -87,11 +187,23 @@ class DynamicLibrary {
     }
 
   private:
+    [[nodiscard]] bool loadNative(const std::string& path) {
+#ifdef _WIN32
+        const fs::path nativePath(path);
+        m_handle = LoadLibraryW(nativePath.c_str());
+#else
+        dlerror();
+        m_handle = dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL);
+#endif
+        return m_handle != nullptr;
+    }
+
 #ifdef _WIN32
     HMODULE m_handle = nullptr;
 #else
     void* m_handle = nullptr;
 #endif
+    std::string m_shadowPath;
 };
 
 std::string getLastDynamicLibraryError() {

--- a/tests/plugin_loader_tests.cpp
+++ b/tests/plugin_loader_tests.cpp
@@ -1,10 +1,13 @@
 #include "hotplugpp/plugin_loader.hpp"
 
+#include <atomic>
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
+#include <random>
+#include <string>
 #include <thread>
 
 namespace hotplugpp {
@@ -47,6 +50,56 @@ bool touchPluginFile(const fs::path& path) {
 
     fs::last_write_time(path, currentWriteTime + std::chrono::seconds(1), error);
     return !error;
+}
+
+// Filename prefix the loader uses for its co-located shadow copies. Kept in sync
+// with makeShadowCopy() in src/plugin_loader.cpp.
+constexpr const char* kShadowPrefix = ".hotplugpp-shadow-";
+
+// Creates a fresh, uniquely-named temp subdirectory so shadow-copy assertions are
+// isolated from other tests, parallel runs, and stale files. Returns {} on error.
+fs::path makeUniqueTempSubdir() {
+    static std::atomic<unsigned long long> counter{0};
+    std::random_device rd;
+    const auto uniqueId =
+        std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()) + "_" +
+        std::to_string(counter.fetch_add(1)) + "_" + std::to_string(rd());
+    const fs::path dir = fs::temp_directory_path() / ("hotplugpp_test_" + uniqueId);
+
+    std::error_code error;
+    fs::create_directories(dir, error);
+    if (error) {
+        return {};
+    }
+    return dir;
+}
+
+// RAII cleanup for a temp directory tree; runs even when a fatal assertion fires.
+class TempDirRemover {
+  public:
+    explicit TempDirRemover(fs::path path) : m_path(std::move(path)) {}
+    ~TempDirRemover() {
+        std::error_code error;
+        fs::remove_all(m_path, error);
+    }
+    TempDirRemover(const TempDirRemover&) = delete;
+    TempDirRemover& operator=(const TempDirRemover&) = delete;
+
+  private:
+    fs::path m_path;
+};
+
+// Counts loader shadow copies (".hotplugpp-shadow-*") directly inside dir.
+int countShadowFiles(const fs::path& dir) {
+    int count = 0;
+    std::error_code error;
+    for (fs::directory_iterator it(dir, error), end; !error && it != end; it.increment(error)) {
+        const std::string name = it->path().filename().string();
+        if (name.rfind(kShadowPrefix, 0) == 0) {
+            ++count;
+        }
+    }
+    return count;
 }
 
 } // namespace
@@ -369,6 +422,102 @@ TEST_F(PluginLoaderTest, CheckAndReloadWorksWhenWatcherRejectsThePath) {
     loader.unloadPlugin();
     std::error_code error;
     fs::remove(pluginCopyPath, error);
+}
+
+// ============================================================================
+// Shadow Copy / Windows DLL-lock Regression Tests
+// ============================================================================
+
+// Primary regression for the Windows DLL-lock bug: the build-output file must stay
+// writable while the plugin is loaded, so a rebuild can overwrite it and trigger a
+// hot-reload. Before shadow copying, LoadLibrary held an exclusive lock on the
+// original file and this overwrite failed on Windows (ERROR_SHARING_VIOLATION).
+TEST_F(PluginLoaderTest, ReloadAfterOverwritingLoadedLibrary) {
+    const fs::path dir = makeUniqueTempSubdir();
+    ASSERT_FALSE(dir.empty());
+    TempDirRemover dirGuard(dir);
+
+    const fs::path loadedPath =
+        dir / (std::string(SHARED_LIB_PREFIX) + "reload_overwrite" + SHARED_LIB_SUFFIX);
+    std::error_code error;
+    fs::copy_file(m_testPluginPath, loadedPath, fs::copy_options::overwrite_existing, error);
+    ASSERT_FALSE(error) << error.message();
+
+    PluginLoader loader;
+    int callbackCount = 0;
+    loader.setReloadCallback([&callbackCount]() { ++callbackCount; });
+
+    ASSERT_TRUE(loader.loadPlugin(loadedPath.string()));
+    ASSERT_TRUE(loader.isLoaded());
+
+    // Crux of the regression: overwrite the original file while the plugin is
+    // loaded. This must succeed because the loader holds only the shadow copy.
+    error.clear();
+    fs::copy_file(m_testPluginPath, loadedPath, fs::copy_options::overwrite_existing, error);
+    ASSERT_FALSE(error) << "loaded plugin file is locked (shadow copy missing?): "
+                        << error.message();
+
+    // Ensure the modification time advances so the change is detected.
+    ASSERT_TRUE(touchPluginFile(loadedPath));
+
+    bool reloaded = false;
+    for (int attempt = 0; attempt < 30; ++attempt) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        if (loader.checkAndReload() == PluginLoader::ReloadResult::Reloaded) {
+            reloaded = true;
+            break;
+        }
+    }
+
+    EXPECT_TRUE(reloaded);
+    EXPECT_GE(callbackCount, 1);
+    EXPECT_TRUE(loader.isLoaded());
+
+    loader.unloadPlugin();
+}
+
+// The loader must clean up its co-located shadow copy when the plugin is unloaded.
+TEST_F(PluginLoaderTest, ShadowCopyRemovedAfterUnload) {
+    const fs::path dir = makeUniqueTempSubdir();
+    ASSERT_FALSE(dir.empty());
+    TempDirRemover dirGuard(dir);
+
+    const fs::path loadedPath =
+        dir / (std::string(SHARED_LIB_PREFIX) + "shadow_cleanup" + SHARED_LIB_SUFFIX);
+    std::error_code error;
+    fs::copy_file(m_testPluginPath, loadedPath, fs::copy_options::overwrite_existing, error);
+    ASSERT_FALSE(error) << error.message();
+
+    PluginLoader loader;
+    ASSERT_TRUE(loader.loadPlugin(loadedPath.string()));
+
+    // Exactly one shadow copy should exist alongside the original while loaded.
+    EXPECT_EQ(countShadowFiles(dir), 1) << "expected one shadow copy while loaded";
+
+    loader.unloadPlugin();
+
+    // The shadow copy must be gone after unload (only the original remains).
+    EXPECT_EQ(countShadowFiles(dir), 0) << "shadow copy not removed after unload";
+}
+
+// A failed load (e.g. a corrupt library) must not leave a shadow copy behind: the
+// loader creates the shadow, the native load fails, and cleanup must remove it.
+TEST_F(PluginLoaderTest, FailedLoadLeavesNoShadowCopy) {
+    const fs::path dir = makeUniqueTempSubdir();
+    ASSERT_FALSE(dir.empty());
+    TempDirRemover dirGuard(dir);
+
+    const fs::path badPath =
+        dir / (std::string(SHARED_LIB_PREFIX) + "not_a_library" + SHARED_LIB_SUFFIX);
+    {
+        std::ofstream bad(badPath, std::ios::binary);
+        bad << "this is not a valid shared library";
+    }
+
+    PluginLoader loader;
+    EXPECT_FALSE(loader.loadPlugin(badPath.string()));
+    EXPECT_FALSE(loader.isLoaded());
+    EXPECT_EQ(countShadowFiles(dir), 0) << "shadow copy left behind after a failed load";
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Hot-reload was broken on Windows: `PluginLoader` loaded the build-output `.dll`
directly, and Windows holds an **exclusive lock** on a loaded DLL — so the next
rebuild could not overwrite the file and the reload never fired. (POSIX `dlopen`
does not lock the inode, so Linux/macOS were unaffected.)

This change makes the loader load a **co-located shadow copy** of the library
instead of the original:

- On load, the library is copied to a uniquely named sibling file
  `.hotplugpp-shadow-<name>-<pid>-<n>.<ext>` in the **same directory**, and that
  copy is loaded (`LoadLibraryW` on Windows, `dlopen` on POSIX). The original
  build-output file is never opened by the loader, so a rebuild can overwrite it.
- The shadow filename differs from the watched original, so the file watcher
  ignores its create/delete events — no reload loop.
- The copy is removed on unload, on reload, and on a failed load.
- Co-locating the copy (instead of a temp dir) keeps Windows dependency resolution
  identical to before and preserves `$ORIGIN`/`@loader_path` on POSIX.
- If the plugin directory is not writable, it falls back to a direct load of the
  original (loading still works; on Windows hot-reload may not, exactly as today).

Applied on all platforms for uniform behavior.

> Rebased onto the latest `main`. Builds on the PImpl refactor from #27: the
> shadow-copy logic lives entirely inside the internal `DynamicLibrary` RAII type,
> so the **public header is unchanged**.

## Design

```mermaid
flowchart TD
    subgraph Build["External build (linker)"]
        B1["Rebuild plugin, overwrite original"]
    end

    subgraph Disk["Plugin directory (one folder)"]
        ORIG["Original: plugin.dll<br/>(watched, NOT locked by loader)"]
        SHADOW[".hotplugpp-shadow-plugin-pid-n.dll<br/>(co-located copy, locked while loaded)"]
    end

    subgraph Host["Host thread (PluginLoader / DynamicLibrary)"]
        L1["loadPlugin(path)"]
        L2["makeShadowCopy: copy ORIG to SHADOW (retry)"]
        L3["LoadLibraryW(SHADOW) / dlopen<br/>plain load; siblings + ORIGIN resolve from same dir"]
        L4["resolve createPlugin / destroyPlugin"]
        C1["checkAndReload()"]
        C2["unloadPlugin: FreeLibrary/dlclose + delete SHADOW"]
    end

    subgraph Watcher["Watcher thread"]
        W1["watch dir, filter by ORIGINAL filename"]
        W2["mark reloadPending<br/>(shadow filename filtered out, no loop)"]
    end

    L1 --> L2 --> L3 --> L4
    L3 -. loads .-> SHADOW
    L2 -. reads .-> ORIG
    B1 -- "overwrites (now allowed)" --> ORIG
    ORIG -- mtime change --> W1 --> W2
    W2 -. consumeReloadSignal .-> C1
    C1 --> C2 --> L1
```

## Acceptance Criteria Mapping

- [x] Rebuilding a loaded plugin on Windows no longer fails with a sharing
      violation; the reload fires.
- [x] No public header change — the shadow-copy state is internal to the
      `DynamicLibrary` RAII type (builds on the #27 PImpl refactor).
- [x] Shadow copies are cleaned up (unload / reload / failed load) and never
      committed (they match the gitignored `*.dll`/`*.so`/`*.dylib` patterns).

## Validation

Built and tested clean-state on Windows (MSVC 14.50, Ninja, GoogleTest + efsw),
rebased onto latest `main`:

- [x] `cmake -S . -B build`
- [x] `cmake --build build --target build_hotplugpp_tests`
- [x] `ctest --test-dir build --output-on-failure` — **100% tests passed**
- [x] `cmake -P scripts/check-format.cmake` — *All files are properly formatted*

New tests: `ReloadAfterOverwritingLoadedLibrary` (overwrite-while-loaded then
reload — fails on the old code on Windows, passes here), `ShadowCopyRemovedAfterUnload`,
`FailedLoadLeavesNoShadowCopy`. Existing `#27` public-header hygiene test still passes.

## Risk Review

- [x] API compatibility checked — the **public header is unchanged**; shadow state
      is internal to `DynamicLibrary`.
- [x] Runtime hot-reload behavior checked — overwrite-while-loaded reload verified
      on Windows; existing reload / coalesce / watcher-fallback tests still green.
- [x] Cross-platform impact considered — shadow copy on all platforms; co-location
      preserves POSIX `$ORIGIN`/`@loader_path`; Windows search order unchanged.

## Documentation

- [x] `README.md` (shadow-copy note), `docs/hot-reload-watcher.md` (new section),
      `CHANGELOG.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
